### PR TITLE
Set Content-Type for all OPA POST requests

### DIFF
--- a/internal/clients/opa.go
+++ b/internal/clients/opa.go
@@ -37,6 +37,9 @@ func (c *OPAClient) Do(ctx context.Context, method, url string, body io.Reader) 
 	if err != nil {
 		return nil, err
 	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	return c.HTTPClient.Do(req)
 }
 

--- a/internal/clients/opa_test.go
+++ b/internal/clients/opa_test.go
@@ -1,0 +1,32 @@
+package clients
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDoSetsContentType(t *testing.T) {
+	var receivedContentType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c, err := NewOPAClient(server.URL)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	_, err = c.Do(context.Background(), http.MethodPost, server.URL+"/test", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("Do returned error: %v", err)
+	}
+
+	if receivedContentType != "application/json" {
+		t.Errorf("Content-Type header = %q, want %q", receivedContentType, "application/json")
+	}
+}


### PR DESCRIPTION
## Summary
- move `Content-Type` header logic from EvaluatePolicy to the common `Do` method
- update unit test to verify `Do` adds the header

## Testing
- `go test ./...` *(fails: unable to fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_686dfdd1b6e0832e81470470c1c0c9f2